### PR TITLE
Add icon metadata to layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,9 @@ import { ReactNode } from 'react'
 
 export const metadata = {
   title: 'CardsEditor',
+  icons: {
+    icon: '/images/profile.png',
+  },
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary
- add `/images/profile.png` as the site icon in `app/layout.tsx`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68417efb270c832682b8a7a84405df78